### PR TITLE
Updated CSS Classes to be Static

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -52,7 +52,7 @@ module.exports = {
         test: /\.(scss|css)$/,
         include: [path.resolve(__dirname, "src/components")],
         loader: ExtractTextPlugin.extract("style?singleton", [
-          `css-loader?modules&importLoaders=1&sourceMap=${CSS_MAPS}`,
+          `css-loader?modules&importLoaders=1&sourceMap=${CSS_MAPS}&localIdentName=traitify--[folder]--[local]`,
           "postcss-loader",
           `sass-loader?sourceMap=${CSS_MAPS}`
         ].join("!"))


### PR DESCRIPTION
We use CSS-Modules for generating classnames. I added an option so that names will be in the format `traitify--{folder name}--{original class name}`. The documentation for it is below if you're interested

https://github.com/css-modules/postcss-modules/tree/master#generating-scoped-names
https://github.com/webpack/loader-utils#interpolatename