### PR TITLE
Bump to Version 1.12.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traitify-widgets",
-  "version": "1.12.15",
+  "version": "1.12.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "traitify-widgets",
-      "version": "1.12.15",
+      "version": "1.12.16",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traitify-widgets",
-  "version": "1.12.15",
+  "version": "1.12.16",
   "description": "Traitiy Widgets",
   "repository": "github:traitify/traitify-widgets",
   "main": "./build/traitify.js",


### PR DESCRIPTION
This fixes a bug with displaying jobs in the career results modal that stems from an incorrect build of version 1.12.15 in npm