### PR TITLE
Fixed memory leaks in survey components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traitify-widgets",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "traitify-widgets",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traitify-widgets",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Traitiy Widgets",
   "repository": "github:traitify/traitify-widgets",
   "main": "./build/traitify.js",

--- a/src/components/survey/cognitive/helpers.js
+++ b/src/components/survey/cognitive/helpers.js
@@ -1,5 +1,6 @@
 import {useEffect, useReducer} from "react";
 import mutable from "lib/common/object/mutable";
+import useSafeDispatch from "lib/hooks/use-safe-dispatch";
 
 export function loadImage({dispatch, imageType, url}) {
   dispatch({type: "imageLoading"});
@@ -81,8 +82,9 @@ export function reducer(state, action) {
 export function useQuestionsLoader(initialQuestions) {
   const [
     {error, imageLoading, loading, questions},
-    dispatch
+    unsafeDispatch
   ] = useReducer(reducer, {questions: initialQuestions});
+  const dispatch = useSafeDispatch(unsafeDispatch);
 
   useEffect(() => dispatch({questions: initialQuestions, type: "reset"}), [initialQuestions]);
   useEffect(() => {

--- a/src/components/survey/personality/use-slide-loader.js
+++ b/src/components/survey/personality/use-slide-loader.js
@@ -2,6 +2,7 @@ import {useEffect, useReducer} from "react";
 import except from "lib/common/object/except";
 import mutable from "lib/common/object/mutable";
 import useElementSize from "lib/hooks/use-element-size";
+import useSafeDispatch from "lib/hooks/use-safe-dispatch";
 
 const defaultState = {
   error: null,
@@ -108,8 +109,9 @@ export default function useSlideLoader({element, translate}) {
   const size = useElementSize(element);
   const [
     {error, imageLoading, imageLoadingAttempts, ready, slideIndex, slides},
-    dispatch
+    unsafeDispatch
   ] = useReducer(reducer, {...defaultState, ready: false, size, slideIndex: -1, slides: []});
+  const dispatch = useSafeDispatch(unsafeDispatch);
 
   useEffect(() => { dispatch({size, type: "resize"}); }, [...size]);
   useEffect(() => {

--- a/src/lib/hooks/use-safe-dispatch.js
+++ b/src/lib/hooks/use-safe-dispatch.js
@@ -1,0 +1,17 @@
+import {useCallback, useLayoutEffect, useRef} from "react";
+
+export default function useSafeDispatch(unsafeDispatch) {
+  const mounted = useRef(false);
+
+  useLayoutEffect(() => {
+    mounted.current = true;
+
+    return () => { mounted.current = false; };
+  }, []);
+
+  return useCallback((...options) => {
+    if(!mounted.current) { return; }
+
+    unsafeDispatch(...options);
+  }, [unsafeDispatch]);
+}


### PR DESCRIPTION
The components would unmount due to a change in the assessment state, but the dispatch would still occur from image onLoad/onError or other similar actions