### PR TITLE
Fixed issue loading crosschq external assessment

### DIFF
--- a/src/components/container/hooks/use-order-polling.js
+++ b/src/components/container/hooks/use-order-polling.js
@@ -97,7 +97,6 @@ export default function useOrderPolling() {
         const currentAssessment = currentOrder.assessments
           .find(({id}) => id === latestAssessment.id);
         if(currentAssessment && currentAssessment.completed !== latestAssessment.completed) {
-          // NOTE: May need to reset assessmentQuery for personality results
           changes = true;
           currentAssessment.completed = currentAssessment.completed || latestAssessment.completed;
         } else if(!currentAssessment) {

--- a/src/components/status/index.js
+++ b/src/components/status/index.js
@@ -15,7 +15,7 @@ import Timeout from "./timeout";
 
 export default function Status() {
   const active = useActive();
-  const [activeLoading, setActiveLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
   const order = useOrder();
   const showHelp = useOption("showHelp");
   const [showHelpModal, setShowHelpModal] = useState(false);
@@ -24,19 +24,20 @@ export default function Status() {
 
   useComponentEvents("Status", {order});
   useEffect(() => {
-    if(active?.surveyType !== "external") { return; }
-    if(active.completed) { return; }
+    const load = (active?.surveyType === "external" && !active.completed)
+      || order?.status === "error";
+    setLoading(load);
+    if(!load) { return; }
 
-    setActiveLoading(true);
-
-    const timeout = setTimeout(() => { setActiveLoading(false); }, 5000);
+    const timeout = setTimeout(() => { setLoading(false); }, 5000);
     return () => { clearTimeout(timeout); };
-  }, [active?.id, active?.completed]);
+  }, [active?.id, active?.completed, order?.status]);
 
   if(!order) { return null; }
-  if(order.status === "error") { return <Error />; }
   if(order.status === "skipped") { return <Skipped />; }
-  if(activeLoading || active?.loading || order.status === "loading") { return <Loading />; }
+  if(loading) { return <Loading />; }
+  if(order.status === "error") { return <Error />; }
+  if(active?.loading || order.status === "loading") { return <Loading />; }
   if(order.status === "timeout") { return <Timeout />; }
   if(assessments.length === 0) { return null; }
 

--- a/src/lib/common/errors.js
+++ b/src/lib/common/errors.js
@@ -20,7 +20,14 @@ export function errorsToText(prepend, _errors) {
 }
 
 export function getResponseErrors(response) {
-  if(isObject(response) && isArray(response.errors)) { return response.errors; }
+  if(isObject(response) && isArray(response.errors)) {
+    return response.errors.map((error) => {
+      if(isObject(error) && isString(error.message)) { return error.message; }
+      if(isString(error)) { return error; }
+
+      return JSON.stringify(error);
+    });
+  }
   if(isObject(response) && isString(response.errors)) { return [response.errors]; }
   if(isObject(response) && isString(response.error)) { return [response.error]; }
   if(isObject(response) && isString(response.errorMessage)) { return [response.errorMessage]; }

--- a/src/lib/recoil/order.js
+++ b/src/lib/recoil/order.js
@@ -110,7 +110,8 @@ const baseRecommendationQuery = selector({
 
     let {order, response} = await fetchRecommendation(initialExpirationFlag);
 
-    // TODO(remove ~2026-12-01): workaround for server-side inconsistency in applyAssessmentExpiration handling.
+    // TODO: remove ~2026-12-01
+    // workaround for server-side inconsistency in applyAssessmentExpiration handling.
     if(options.retryRecommendationOnIncompletePersonality && hasExpirationFlag && !order.errors) {
       const personality = response.data?.recommendation?.prerequisites?.personality;
       if(personality?.surveyId && !personality.assessmentId) {


### PR DESCRIPTION
Fixes 2 issues
- Infinite loading because `activeLoading` wasn't always set to false when assessment loads
  - Potentially related to surveyType returning null from the external API
- Order Not Found would show an error instead of loading screen
  - Now waits 5 seconds if order is in error state/polling